### PR TITLE
react on relevant posix SIG signals

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,23 @@
 import getServer from "./server/index.js";
 import client from './client.js'
 
-getServer(client).then(app => app.listen(8080, '0.0.0.0'));
+const server = await getServer(client).then(app => app.listen(8080, '0.0.0.0'));
+
+
+var signals = {
+    'SIGINT': 2,
+    'SIGTERM': 15
+};
+
+function shutdown(signal, value) {
+    server.close(function () {
+        console.log('server stopped by ' + signal);
+        process.exit(128 + value);
+    });
+}
+
+Object.keys(signals).forEach(function (signal) {
+    process.on(signal, function () {
+        shutdown(signal, signals[signal]);
+    });
+});


### PR DESCRIPTION
See https://docs.docker.com/engine/reference/commandline/stop/ :
`The main process inside the container will receive SIGTERM, and after a grace period, SIGKILL`

By default node does not react on SIGTERM, so just a small change to make it happen.
Basically docker will try to gracefully shut down the process, which will cause the application to close the server now, which will at first handle all pending connections and then gracefully shut down